### PR TITLE
Updated to work with latest versions of Greynir and ReynirPackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # Docker images for Greynir
-## A natural language processor for Icelandic
-https://github.com/vthorsteinsson/Reynir
+*A natural language processor for Icelandic* - https://github.com/vthorsteinsson/Reynir
 
-Docker-compose will run the Greynir application cluster. This consists of two Docker
-images, a *database image* (exposing PostgreSQL at port 5432 by default) and a *web image*
-(exposing a HTTP server on port 5000 by default).
+This repository contains Dockerfiles and a `docker-compose.yml` file for container images
+related to Greynir.
+
+A simple Greynir application cluster can be built and run via `docker-compose`. This consists of
+two Docker images, a *database image* (exposing PostgreSQL at port 5432 by default) and
+a *web image* (exposing a HTTP server on port 5000 by default).
 
 ## Third party data
 Make sure that Icelandic dictionary files from BÍN (*Beygingarlýsing íslensks nútímamáls*)
-are added to the `greynir-docker-db` directory before building the database container.
-These files are not included in the Greynir distribution and must be obtained separately.
+are added to the `greynir-docker/db` directory before building the database container.
+These files are not included in the Greynir distribution and must be obtained separately,
+as they are copyright(C) by *Stofnun Árna Magnússonar í íslenskum fræðum*.
 
 See the Greynir README for further details.
 
-https://github.com/vthorsteinsson/Reynir
-
 ## How to run
+
+`cd greynir-docker`
+
 Attached to console: `docker-compose up`
 Detached from console: `docker-compose -d up`
 
@@ -53,7 +57,8 @@ The default settings will expose the web server on port 5000.
 
 
 ## Running several containers
-`greynir_web` depends on the `GREYNIR_DB_HOST` and `GREYNIR_DB_PORT` environment variables. If there is a need to run multiple instances of Greynir you can set these variables when you run greynir_web.
+The `greynir/web` image depends on the `GREYNIR_DB_HOST` and `GREYNIR_DB_PORT` environment variables.
+To run multiple instances of Greynir you can set these variables when you run `greynir/web`.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ image and exposing a HTTP server on port 5050 by default).
 
 ## How to run
 
-`cd greynir-docker`
+```bash
+cd greynir-docker
+```
 
 Attached to console: `docker-compose up`
+
 Detached from console: `docker-compose -d up`
 
 Attached-mode will display all output from the containers in the console.
@@ -24,27 +27,33 @@ Attached-mode will display all output from the containers in the console.
 
 ## Building the database container image
 
-`cd greynir-docker/db`
-
-`docker build -t greynir/db .`
+```bash
+cd greynir-docker/db
+docker build -t greynir/db .
+```
 
 ## Running the database container
 
 This will expose the Greynir database on port 5432.
 
-`docker run -d --name greynir_db -p 5432:5432 greynir/db`
+```bash
+docker run -d --name greynir_db -p 5432:5432 greynir/db
+```
 
 ## Building the web container image
 
-`cd greynir-docker/web`
-
-`docker build -t greynir/web .`
+```bash
+cd greynir-docker/web
+docker build -t greynir/web .
+```
 
 ## Running the web container
 
 The default settings will expose the web server on port 5050.
 
-`docker run -d --name greynir_web -p 5050:5000 --link greynir_db greynir/web`
+```bash
+docker run -d --name greynir_web -p 5050:5000 --link greynir_db greynir/web
+```
 
 ## Running several containers
 
@@ -56,6 +65,12 @@ when you run `greynir/web`.
 
 Example:
 
-`docker run --name <new_greynir_db> -p <new-db-port>:5432 greynir/db`
+```bash
+docker run --name <new_greynir_db> -p <new-db-port>:5432 greynir/db
 
-`docker run --name <new_greynir_web> -e GREYNIR_DB_HOST=<new_greynir_db> -e GREYNIR_DB_PORT=<new_db_port> -p <new-web-port>:5000 --link <new_greynir_db> greynir/web`
+docker run --name <new_greynir_web> \
+	-e GREYNIR_DB_HOST=<new_greynir_db> \
+	-e GREYNIR_DB_PORT=<new_db_port> \
+	-p <new-web-port>:5000 \
+	--link <new_greynir_db> greynir/web
+```

--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
 # Docker images for Greynir
-*A natural language processor for Icelandic* - https://github.com/vthorsteinsson/Reynir
 
-This repository contains Dockerfiles and a `docker-compose.yml` file for container images
-related to Greynir.
+*A natural language processor for Icelandic* -
+https://github.com/vthorsteinsson/Reynir
 
-A simple Greynir application cluster can be built and run via `docker-compose`. This consists of
-two Docker images, a *database image* (exposing PostgreSQL at port 5432 by default) and
-a *web image* (exposing a HTTP server on port 5000 by default).
+This repository contains Dockerfiles and a `docker-compose.yml` file
+for container images related to Greynir.
 
-## Third party data
-Make sure that Icelandic dictionary files from BÍN (*Beygingarlýsing íslensks nútímamáls*)
-are added to the `greynir-docker/db` directory before building the database container.
-These files are not included in the Greynir distribution and must be obtained separately,
-as they are copyright(C) by *Stofnun Árna Magnússonar í íslenskum fræðum*.
-
-See the Greynir README for further details.
+A simple Greynir application cluster can be built and run via `docker-compose`.
+This consists of two Docker images, a *database image* (containing
+a PostgreSQL server) and a *web image* (connecting to the database
+image and exposing a HTTP server on port 5050 by default).
 
 ## How to run
 
@@ -28,40 +23,39 @@ Attached-mode will display all output from the containers in the console.
 # Building and running the images separately
 
 ## Building the database container image
-If you already have PostgreSQL running on your server at port 5432, stop the service first
-or you will get a port conflict. (Alternatively, configure
-the Greynir database container to use a different port using the `GREYNIR_DB_PORT`
-environment variable).
 
 `cd greynir-docker/db`
-
-Make sure that the files `obeyg.smaord.txt`, `plastur.feb2013.txt` and `SHsnid.csv` are present in the directory
-before starting the build.
 
 `docker build -t greynir/db .`
 
 ## Running the database container
+
 This will expose the Greynir database on port 5432.
 
 `docker run -d --name greynir_db -p 5432:5432 greynir/db`
 
 ## Building the web container image
+
 `cd greynir-docker/web`
 
 `docker build -t greynir/web .`
 
 ## Running the web container
-The default settings will expose the web server on port 5000.
 
-`docker run -d --name greynir_web -p 5000:5000 --link greynir_db greynir/web`
+The default settings will expose the web server on port 5050.
 
+`docker run -d --name greynir_web -p 5050:5000 --link greynir_db greynir/web`
 
 ## Running several containers
-The `greynir/web` image depends on the `GREYNIR_DB_HOST` and `GREYNIR_DB_PORT` environment variables.
-To run multiple instances of Greynir you can set these variables when you run `greynir/web`.
+
+The `greynir/web` image uses the `GREYNIR_DB_HOST` and `GREYNIR_DB_PORT`
+environment variables to connect to the database.
+
+To run multiple instances of Greynir you can set these variables
+when you run `greynir/web`.
 
 Example:
 
 `docker run --name <new_greynir_db> -p <new-db-port>:5432 greynir/db`
 
-`docker run --name <new_greynir_web> -e "GREYNIR_DB_HOST=new_greynir_db" -p <new-web-port>:5000 --link <new_greynir_db> greynir/web`
+`docker run --name <new_greynir_web> -e GREYNIR_DB_HOST=<new_greynir_db> -e GREYNIR_DB_PORT=<new_db_port> -p <new-web-port>:5000 --link <new_greynir_db> greynir/web`

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,27 +1,8 @@
 FROM postgres:latest
-MAINTAINER Jón Levy <nonni@nonni.cc>
-
-# Install git and python
-RUN apt-get update && apt-get install -y git python3.4
 
 # Set the locale
 RUN localedef -i is_IS -c -f UTF-8 -A /usr/share/locale/locale.alias is_IS.UTF-8
 
 ENV LANG is_IS.utf8
-
-# Clone the Greynir repo
-RUN mkdir -p /srv/greynir-data
-WORKDIR /srv/greynir-data
-
-RUN git clone https://github.com/vthorsteinsson/Reynir.git
-
-WORKDIR /srv/greynir-data/Reynir 
-
-ADD obeyg.smaord.txt resources/obeyg.smaord.txt
-ADD plastur.feb2013.txt resources/plastur.feb2013.txt
-ADD SHsnid.csv resources/SHsnid.csv
-
-WORKDIR /srv/greynir-data/Reynir/utils
-RUN python3.4 external_data_validator.py
 
 ADD sql/initial_setup.sql /docker-entrypoint-initdb.d/initial_setup.sql

--- a/db/sql/initial_setup.sql
+++ b/db/sql/initial_setup.sql
@@ -1,24 +1,8 @@
-create role reynir with password 'reynir';
-create role notandi with password 'notandi';
 
-alter role notandi with superuser;
+alter role reynir with superuser;
 
-alter role notandi with login;
-alter role reynir with login;
-
-create database bin with encoding 'UTF8' LC_COLLATE='is_IS.UTF-8' LC_CTYPE='is_IS.UTF-8' TEMPLATE=template0;
-\c bin;
-create table ord (stofn varchar(80), utg integer, ordfl varchar(20), fl varchar(20), ordmynd varchar(80), beyging varchar(24));
-copy ord from '/srv/greynir-data/Reynir/resources/ord.csv' with (format csv, delimiter ';', encoding 'UTF8');
-create index ffx on ord(fl);
-create index ofx on ord(ordfl);
-create index oix on ord(ordmynd);
-create index sfx on ord(stofn);
-grant select on ord to reynir;
-grant all on ord to notandi;
 create database scraper with encoding 'UTF8' LC_COLLATE='is_IS.utf8' LC_CTYPE='is_IS.utf8' TEMPLATE=template0;
 grant all privileges on database scraper to reynir;
-grant all privileges on database scraper to notandi;    
 \c scraper;
 create extension if not exists "uuid-ossp";
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,21 @@
-version: '2'
-services:  
+version: '3'
+services:
+
+  db:
+    build: ./db
+    image: greynir/db
+    container_name: greynir_db
+    environment:
+      - POSTGRES_USER=reynir
+      - POSTGRES_PASSWORD=reynir
 
   web:
     build: ./web
     image: greynir/web
     container_name: greynir_web
     ports: 
-      - 0.0.0.0:5000:5000
-    links: 
-      - postgres
+      - "5050:5000"
     depends_on: 
-      - postgres
+      - db
     restart: always
-
-  postgres:
-    build: ./db
-    image: greynir/db
-    container_name: greynir_db
-    ports: 
-      - 0.0.0.0:5432:5432
-
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,33 +1,33 @@
 FROM pypy:3
 
-MAINTAINER Jon Levy "nonni@nonni.cc"
-
 # Update aptitude with new repo and install software 
-RUN apt-get update && apt-get install -y git build-essential
+RUN apt-get update \
+	&& apt-get install -y git build-essential
 
-RUN apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
+RUN apt-get install -y locales \
+	&& rm -rf /var/lib/apt/lists/* \
     && localedef -i is_IS -c -f UTF-8 -A /usr/share/locale/locale.alias is_IS.UTF-8
 
 ENV LANG is_IS.utf8
+ENV LANGUAGE is_IS:is
 
 # Clone the Greynir repo
 RUN mkdir -p /usr/src/app
 
-RUN cd /usr/src/app && git clone https://github.com/vthorsteinsson/Reynir.git
+RUN cd /usr/src/app \
+	&& git clone https://github.com/vthorsteinsson/Reynir.git
 
-RUN cd /usr/src/app/Reynir && pip install -r requirements.txt && make
-
-# Build the ordalisti.text.dawg file
-RUN cd /usr/src/app/Reynir/utils && pypy3 dawgbuilder.py
+# Install requirements
+RUN cd /usr/src/app/Reynir \
+	&& pip install --upgrade pip \
+	&& pip install --no-cache-dir -r requirements.txt
 
 ENV GREYNIR_DB_HOST=greynir_db GREYNIR_DB_PORT=5432
 
 WORKDIR /usr/src/app/Reynir
 
-EXPOSE 5000
-
+# Initialize the database tables (nondestructively)
+# and run the Flask server on port 5000 (exposed at port 5050)
 ENTRYPOINT pypy3 scraperinit.py && exec pypy3 main.py
 
 #VOLUME /usr/src/app/Reynir/resources
-
-


### PR DESCRIPTION
The `Dockerfile`s and `docker-compose.yml` file have been updated and simplified to work with the newest versions of Greynir and ReynirPackage. Greynir now uses ReynirPackage for all parsing and vocabulary needs, and ReynirPackage no longer requires BÍN to be accessible via a SQL database. This makes the database setup significantly easier and more straightforward. To minimize clashes with other Postgres and Flask clients, the `docker-compose.yml` file now no longer exposes the PSQL port (5432) and the web is by default exposed on port 5050 instead of 5000.